### PR TITLE
fix: stack overflow on MP3s with large embedded cover art

### DIFF
--- a/src/lib/components/audio/Metadata.svelte
+++ b/src/lib/components/audio/Metadata.svelte
@@ -2,6 +2,7 @@
 	import Icon from '@iconify/svelte';
 	import type { Tags } from 'jsmediatags/types';
 	import { createEventDispatcher } from 'svelte';
+	import { bytesToBase64 } from '$lib/util';
 	import downloadIcon from '@iconify-icons/mdi/download';
 	import clearIcon from '@iconify-icons/mdi/close';
 	import revertIcon from '@iconify-icons/mdi/undo';
@@ -84,7 +85,7 @@
 	function downloadCover() {
 		if (tags?.picture?.data) {
 			const a = document.createElement('a');
-			a.href = `data:${tags.picture.format};charset=utf-8;base64,${btoa(String.fromCharCode.apply(null, tags.picture.data))}`;
+			a.href = `data:${tags.picture.format};charset=utf-8;base64,${bytesToBase64(tags.picture.data)}`;
 			a.download = `catcut_cover_${basename}.${tags.picture.format.split('/')[1]}`;
 			a.click();
 			a.remove();

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -42,6 +42,14 @@ export function blobToDataURL(blob: Blob): Promise<string> {
 	});
 }
 
+export function bytesToBase64(data: number[]): string {
+	let binary = '';
+	const chunkSize = 0x8000;
+	for (let i = 0; i < data.length; i += chunkSize)
+		binary += String.fromCharCode.apply(null, data.slice(i, i + chunkSize));
+	return btoa(binary);
+}
+
 export function splitFilename(filename: string): [string, string] {
 	const reverseParts = filename.split('.').reverse();
 	return [reverseParts.slice(1).reverse().join('.'), reverseParts[0]];

--- a/src/routes/AudioEditor.svelte
+++ b/src/routes/AudioEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ProcessingState, RemoteFile, splitFilename, validEvent } from '$lib/util';
+	import { bytesToBase64, ProcessingState, RemoteFile, splitFilename, validEvent } from '$lib/util';
 	import { filesize } from 'filesize';
 	import ms from 'pretty-ms';
 	import type { Tags } from 'jsmediatags/types';
@@ -345,7 +345,7 @@
 	let tagType: string | null = null;
 	$: console.log(`Audio metadata (${tagType})`, audioTags);
 	$: coverSrc = audioTags?.picture?.data
-		? `data:${audioTags.picture.format};charset=utf-8;base64,${btoa(String.fromCharCode.apply(null, audioTags.picture.data))}`
+		? `data:${audioTags.picture.format};charset=utf-8;base64,${bytesToBase64(audioTags.picture.data)}`
 		: null;
 	$: window.jsmediatags?.read(file instanceof RemoteFile ? file.blob! : file, {
 		onSuccess: (tag) => {


### PR DESCRIPTION
Fixes `RangeError: Maximum call stack size exceeded` when loading MP3s with large embedded cover art. String.fromCharCode.apply(null, picture.data) spreads every byte of the image as a function argument, which overflows the stack on big covers - this converts the bytes to base64 in 32KB chunks instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved album-cover image handling in the audio editor.
  * Large embedded cover images now load more reliably without conversion errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->